### PR TITLE
Fix autoscaler extraEnv: use dict form and extraEnvFrom for secrets

### DIFF
--- a/apps/hetzner/cluster-autoscaler.yaml
+++ b/apps/hetzner/cluster-autoscaler.yaml
@@ -23,18 +23,10 @@ spec:
             instanceType: cx22
             region: nbg1
         extraEnv:
-          - name: HCLOUD_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: hcloud
-                key: token
-          - name: HCLOUD_CLOUD_INIT
-            valueFrom:
-              secretKeyRef:
-                name: hcloud-init-data
-                key: cloud-init
-          - name: HCLOUD_IMAGE
-            value: ubuntu-24.04
+          HCLOUD_IMAGE: ubuntu-24.04
+        extraEnvFrom:
+          - secretRef:
+              name: hcloud-autoscaler-env
         extraArgs:
           scale-down-delay-after-add: 50m
           scale-down-unneeded-time: 5m


### PR DESCRIPTION
extraEnv in the cluster-autoscaler chart is a dict/map, not a list. Passing a list caused the template (range $key, $value) to use list indices as env var names (0, 1, 2) and Go map representations as values, which Kubernetes rejects because env.name must be a string.

Move HCLOUD_TOKEN and HCLOUD_CLOUD_INIT to extraEnvFrom referencing the hcloud-autoscaler-env secret (created manually with correctly-named keys). HCLOUD_IMAGE stays as a plain dict entry under extraEnv.