### PR TITLE
Fix hcloud cloud-init: derive Tailscale advertise-routes from DHCP route

### DIFF
--- a/hetzner/cloud-init-template.yaml
+++ b/hetzner/cloud-init-template.yaml
@@ -65,10 +65,13 @@ runcmd:
   - sysctl -w net.ipv4.conf.all.rp_filter=2
   - sysctl -w net.ipv4.conf.enp7s0.rp_filter=2
 
-  # Advertise the private network subnet over Tailscale so Pi and saraneth can
+  # Advertise the Hetzner private network over Tailscale so Pi and saraneth can
   # reach hcloud flannel VTEP endpoints. The tag:k3s autoApprover in the tailnet
-  # ACL approves this automatically.
-  - tailscale set --advertise-routes=$(ip -4 route show dev enp7s0 scope link | awk '{print $1}' | paste -sd,)
+  # ACL approves this automatically. Hetzner assigns enp7s0 a /32 host address
+  # with a separate DHCP route for the full private network (e.g. 10.30.0.0/16);
+  # derive the subnet from that route — ip route scope link returns only the
+  # gateway host route on Hetzner DHCP, not the network prefix.
+  - tailscale set --advertise-routes=$(ip -4 route show dev enp7s0 | awk '/proto dhcp.*via/{print $1; exit}')
 
   # Join the cluster as an agent node.
   # --node-ip: register the Tailscale IP so the control plane can reach this node.


### PR DESCRIPTION
The `tailscale set --advertise-routes` step in cloud-init was silently a no-op on all new nodes, breaking pod-to-pod routing between the Pi and Hetzner nodes.

Root cause: the previous command used `ip route show dev enp7s0 scope link` to find the subnet to advertise. Hetzner assigns `enp7s0` a `/32` host address — with a `/32` there is no kernel link-scoped subnet route. The filter returned only the DHCP gateway host route (`10.30.0.1`), so `tailscale set --advertise-routes=10.30.0.1` set `AdvertiseRoutes` to null.

Without the subnet route, the Pi had no path to `10.30.0.0/16`, so flannel VXLAN return traffic from the Pi to Hetzner pod IPs was silently dropped. Symptoms: 502 on `longhorn.gentoo-mine.ts.net`, 100% packet loss from any pod on the Pi to any pod on Hetzner.

Fix: derive the subnet from the DHCP network route instead — `ip -4 route show dev enp7s0 | awk '/proto dhcp.*via/{print $1; exit}'` — which yields `10.30.0.0/16`. The `/16` covers all Hetzner DCs; per-DC `/24` scoping is not reliably derivable because Hetzner assigns `/32` addresses and the autoscaler does not enforce DC-subnet boundaries.

The two live affected nodes (hel1, fsn1) have had routes applied manually for the current session. New nodes will pick up the fixed cloud-init automatically.

_claude-sonnet-4-6 — debugging session with Douglas present; root cause found and immediate fix applied manually before this PR_
