### PR TITLE
Omit default CPU limit in limitranges

### DIFF
--- a/kube/limitranges/defaults.yaml
+++ b/kube/limitranges/defaults.yaml
@@ -296,7 +296,7 @@ spec:
   limits:
     - type: Container
       default:
-        cpu: 500m
+        # CPU omitted (instance-manager always asks for 12%)
         memory: 1Gi
       defaultRequest:
         cpu: 50m


### PR DESCRIPTION
Omit default CPU limit for container due to instance-manager behavior.