### PR TITLE
Refactor RBAC and update namespaces for deepseek

### DIFF
--- a/apps/claude/project.yaml
+++ b/apps/claude/project.yaml
@@ -16,6 +16,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: tailscale
       server: https://kubernetes.default.svc
+    - namespace: deepseek
+      server: https://kubernetes.default.svc
   sourceRepos:
     - https://github.com/fluv/kube.git
     - https://github.com/pab1it0/prometheus-mcp-server.git

--- a/claude/deepseek-rbac.yaml
+++ b/claude/deepseek-rbac.yaml
@@ -1,8 +1,19 @@
+# RBAC for using Deepseek in Claude Code
+# read-only access to everything except secrets
+# read-write access to `deepseek` namespace secrets so it can rotate its own creds and access things
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deepseek
+  labels:
+    prometheus: claude
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: deepseek
-  namespace: claude
+  namespace: deepseek
 ---
 # Long-lived token for Claude's kubeconfig.
 # k8s 1.24+ no longer auto-creates SA tokens; this Secret causes the
@@ -11,7 +22,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: deepseek-token
-  namespace: claude
+  namespace: deepseek
   annotations:
     kubernetes.io/service-account.name: deepseek
 type: kubernetes.io/service-account-token
@@ -27,4 +38,28 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: deepseek
-    namespace: claude
+    namespace: deepseek
+---
+# Grant deepseek access to manage its own secrets
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manage-secrets
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deepseek-secrets
+  namespace: deepseek
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-secrets
+subjects:
+  - kind: ServiceAccount
+    name: deepseek
+    namespace: deepseek


### PR DESCRIPTION
Updated namespaces for ServiceAccount and Secret to 'deepseek'. Added RBAC rules for managing secrets.