### PR TITLE
Expand manage-secrets role permissions

### DIFF
--- a/claude/deepseek-rbac.yaml
+++ b/claude/deepseek-rbac.yaml
@@ -48,7 +48,14 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update", "patch", "delete"]
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Added 'get', 'list', and 'watch' verbs to manage-secrets role.